### PR TITLE
Fix/upload image field

### DIFF
--- a/packages/react-hook-form/src/Mezzanine/CropperModal/CropperModal.tsx
+++ b/packages/react-hook-form/src/Mezzanine/CropperModal/CropperModal.tsx
@@ -82,7 +82,7 @@ export const CropperModal: FC<CropperModalProps> = ({
             color="text-primary"
             variant="h3"
           >
-            拆切影像
+            裁切影像
           </Typography>
         )}
         <button

--- a/packages/react-hook-form/src/UploadImageField/UploadImageField.stories.tsx
+++ b/packages/react-hook-form/src/UploadImageField/UploadImageField.stories.tsx
@@ -30,8 +30,25 @@ export const Basic = () => {
           formDataName="file"
           resolve={(res: MockUploadResponse) => res.id + res.whatever} // Will update form filed value
           label="Label Name"
+          text="Upload Image"
           registerName="upload-image-register-name-1"
           aspect={1} // To limit the cropped aspect ratio.
+          annotation={{
+            formats: ['jpeg', 'webp'],
+            maximumMb: 10,
+            recommendedDimension: [968, 576],
+          }}
+          labels={{
+            fileLimitationPrefix: 'File Limit: ',
+            formatPrefix: 'Video Format: ',
+            upload: 'Upload',
+            error: 'Upload Failed',
+            success: 'Complete',
+            failed: 'Failed',
+            resolveRecommendedDimension: (w: number, h: number, wR: number, hR: number) => (
+              `Recommend: up to ${w} x ${h} (ratio: ${wR}:${hR})`
+            ),
+          }}
         />
         <p>
           fullWidth
@@ -83,7 +100,7 @@ export const Basic = () => {
           annotation={{
             formats: ['jpeg', 'webp'],
             maximumMb: 10,
-            recommendedText: '建議尺寸：寬度至少 1600px，高度不限',
+            recommendedDimension: [968, 576],
           }}
         />
         <p>

--- a/packages/react-hook-form/src/UploadImageField/UploadImageField.tsx
+++ b/packages/react-hook-form/src/UploadImageField/UploadImageField.tsx
@@ -28,7 +28,7 @@ import {
   useWatch,
 } from 'react-hook-form';
 import { BaseField } from '../BaseField';
-import { CropperModal } from '../Mezzanine/CropperModal/CropperModal';
+import { CropperModal, CropperModalProps } from '../Mezzanine/CropperModal/CropperModal';
 import { HookFormFieldComponent, HookFormFieldProps } from '../typings/field';
 import { UploadStatus } from '../typings/file';
 import { blobToUrl, byteToMegaByte, fileListToArray } from '../utils';
@@ -57,6 +57,7 @@ export type UploadImageFieldProps = HookFormFieldProps<FieldValues, {
   mimeType?: string;
   previewClassName?: string;
   crop?: boolean;
+  cropperHeader?: CropperModalProps['header'];
   defaultValue?: string;
   resolve: UseUploadHandlersProps['resolve'];
   upload?(blob: string | Blob, fileName?: string): Promise<any>;
@@ -97,6 +98,7 @@ const UploadImageField: HookFormFieldComponent<UploadImageFieldProps> = ({
   control,
   mimeType,
   crop = true,
+  cropperHeader,
   disabled,
   height,
   bearerToken,
@@ -498,6 +500,7 @@ const UploadImageField: HookFormFieldComponent<UploadImageFieldProps> = ({
         onChange={onInputChange}
       />
       <CropperModal
+        header={cropperHeader}
         mimeType={mimeType}
         aspect={aspect}
         open={crop && cropperOpen}

--- a/packages/react-hook-form/src/index.ts
+++ b/packages/react-hook-form/src/index.ts
@@ -26,3 +26,4 @@ export * from './typings/error-message';
 export * from './UploadFileField';
 export * from './DefaultValueField';
 export * from './utils/use-default-value';
+export * from './utils/gcd';

--- a/packages/react-hook-form/src/utils/gcd.ts
+++ b/packages/react-hook-form/src/utils/gcd.ts
@@ -1,0 +1,12 @@
+/**
+ * @param a 數字1
+ * @param b 數字2
+ * @returns 最大公因數
+ */
+export function gcd(a: number, b: number) {
+  if (b) {
+    return gcd(b, a % b);
+  } else {
+    return Math.abs(a);
+  }
+}


### PR DESCRIPTION
- UploadImageField 原先的建議尺寸文字
```
`建議尺寸：${w} x ${h} 以上 (圖像比例為 ${wR}:${hR})`
```
wR, hR 會以其中一個數值為基底，並四捨五入。
現修改為預設「計算兩數的最大公因數」，較符合實際使用者理解的數值。
`EX: 1200:900 => 4:3`
- UploadImageField 支援客製化內部的文字，傳入方式如下：
```javascript
labels={{
   fileLimitationPrefix: 'File Limit: ',
   formatPrefix: 'Video Format: ',
   upload: 'Upload',
   error: 'Upload Failed',
   success: 'Complete',
   failed: 'Failed',
   resolveRecommendedDimension: (w: number, h: number, wR: number, hR: number) => (
      `Recommend: up to ${w} x ${h} (ratio: ${wR}:${hR})`
   ),
}}
```
- 修正 CropperModal typo `拆切影像` => `裁切影像`
- 允許直接從 UploadImageField 傳入 `cropperHeader` 至 `CropperModal.props.header` (bypass)
- export gcd method from root (最大公因數 function)