### PR TITLE
fix(react-hook-form): sync input value and field value

### DIFF
--- a/packages/react-hook-form/src/SearchInputField/SearchInputField.stories.tsx
+++ b/packages/react-hook-form/src/SearchInputField/SearchInputField.stories.tsx
@@ -1,5 +1,5 @@
 import { Message } from '@mezzanine-ui/react';
-import { FC, useMemo } from 'react';
+import { FC, useEffect, useMemo } from 'react';
 import { useForm, useFormContext } from 'react-hook-form';
 import { FormFieldsDebug } from '../FormFieldsDebug';
 import { FormFieldsWrapper } from '../FormFieldsWrapper';
@@ -13,6 +13,7 @@ export const Basic = () => {
   const methods = useForm({
     defaultValues: {
       'test-default-is-undefined': undefined,
+      'test-setValue': '',
     },
   });
 
@@ -22,6 +23,12 @@ export const Basic = () => {
     const { watch } = useFormContext();
     return <p>{watch('search-watcher')}</p>;
   }, []);
+
+  useEffect(() => {
+    setTimeout(() => {
+      methods.setValue('test-setValue', 'Custom set Value');
+    }, 200);
+  }, [methods]);
 
   return (
     <div
@@ -112,6 +119,16 @@ export const Basic = () => {
         >
           Reset Default is undefined
         </button>
+        <p>
+          Test setValue with clearable false
+        </p>
+        <SearchInputField
+          width={300}
+          label="Test setValue"
+          clearable={false}
+          size="large"
+          registerName="test-setValue"
+        />
       </FormFieldsWrapper>
     </div>
   );

--- a/packages/react-hook-form/src/SearchInputField/use-debounced-value.ts
+++ b/packages/react-hook-form/src/SearchInputField/use-debounced-value.ts
@@ -19,7 +19,7 @@ export function useDebouncedValue({
   cancel$,
   onChange,
 }: UseDebouncedValue) {
-  const value = useWatch({ name: inputId || '' });
+  const value = useWatch({ name: inputId || '' }) as string | undefined;
   const [debouncedValue, setDebouncedValue] = useState(value);
 
   const [inputRefElement, setInputElement] = useState(() => (


### PR DESCRIPTION
**Bug description:**

從別處使用 setValue 動態改變 `<SearchInputField />` 內的值，雖然 form value 裡面有改變，但 input 沒有同步，會導致使用者不知道已經有改變值。（已在 storybook 上新增該情境的範例）

**Solution:**
利用 `@mezzanine-ui` 提供的 `useControlValueState` 同步表單值及 input 值