### PR TITLE
fix(react-hook-form): basefield severity fixed, closed #50

### DIFF
--- a/packages/react-hook-form/src/BaseField/BaseField.tsx
+++ b/packages/react-hook-form/src/BaseField/BaseField.tsx
@@ -6,6 +6,7 @@ import {
   FormMessage,
   cx,
 } from '@mezzanine-ui/react';
+import get from 'lodash/get';
 import { baseFieldClasses } from '@mezzanine-ui/react-hook-form-core';
 import {
   CSSProperties, FC,
@@ -63,7 +64,7 @@ const BaseField: FC<BaseFieldProps> = ({
     '--width': width ? `${width}px` : (fullWidth ? '100%' : undefined),
     ...baseFieldStyle,
   } as CSSProperties;
-  const isError = !disabledErrMsg && errors?.[name];
+  const isError = !disabledErrMsg && get(errors, name);
 
   return (
     <FormField

--- a/packages/react-hook-form/src/InputField/InputField.stories.tsx
+++ b/packages/react-hook-form/src/InputField/InputField.stories.tsx
@@ -68,6 +68,25 @@ export const Basic = () => {
 
   const { isValid: method4IsValid, isDirty } = useFormState({ control: methods4.control });
 
+  const methods5 = useForm({
+    defaultValues: {
+      list: [{
+        value: '123',
+      }],
+    },
+    mode: 'onChange',
+  });
+
+  useEffect(() => {
+    methods5.setError(
+      'list[0].value' as 'list.0.value',
+      {
+        type: 'custom',
+        message: 'Default error should be red (severity=error)',
+      },
+    );
+  }, []);
+
   return (
     <div
       style={{ width: '100%', maxWidth: '680px' }}
@@ -204,6 +223,15 @@ export const Basic = () => {
         method4IsDirty =
         {isDirty ? 'true' : 'false'}
 
+      </FormFieldsWrapper>
+      <br />
+      <br />
+      <p>Error display</p>
+      <FormFieldsWrapper methods={methods5}>
+        <InputField
+          required
+          registerName="list[0].value"
+        />
       </FormFieldsWrapper>
     </div>
   );


### PR DESCRIPTION
目前 registerName 只要是在 array 底下，error 的狀態都抓不到，只有顯示出 error 文字。
但正確邏輯應是 severity 也要改變